### PR TITLE
Add CaregiverChildConsent model reference in eligible participants mixin

### DIFF
--- a/flourish_facet/views/eligible_facet_participants_mixin.py
+++ b/flourish_facet/views/eligible_facet_participants_mixin.py
@@ -12,6 +12,7 @@ class EligibleFacetParticipantsMixin:
     facet_consent_model = 'flourish_facet.facetconsent'
     subject_consent_model = 'flourish_caregiver.subjectconsent'
     child_offstudy_model = 'flourish_prn.childoffstudy'
+    flourish_child_consent_model = 'flourish_caregiver.caregiverchildconsent'
 
     @property
     def subject_consent_cls(self):


### PR DESCRIPTION
A CaregiverChildConsent model reference from 'flourish_caregiver' app has been added to 'eligible_facet_participants_mixin.py' in 'flourish_facet' app. This gives a direct pathway to access "caregiverchildconsent" model which will assist in maintaining efficient data handling within the system.